### PR TITLE
strava -> Strava

### DIFF
--- a/configure/strava/index.md
+++ b/configure/strava/index.md
@@ -4,7 +4,7 @@ title: "Configure Strava"
 
 angular_includes:
   - "{{ site.baseurl }}/app/tractdbConfig.js"
-  - "{{ site.baseurl }}/app/loginForstravaApp.js"
+  - "{{ site.baseurl }}/app/loginForStravaApp.js"
 ---
 
 <header>


### PR DESCRIPTION
Interestingly, incorrect capitalization worked on my machine. I thought osx was picky about capitals in filenames.